### PR TITLE
Change the name of the "Quest Preparation" group to just "Preparation…

### DIFF
--- a/TBC/Item-Preparation.lua
+++ b/TBC/Item-Preparation.lua
@@ -2,7 +2,7 @@ RXPGuides.RegisterGuide([[
 #classic
 #version 3
 #group Consita Classic/TBC Launch Guide
-#subgroup 2 - Quest Preparation
+#subgroup 2 - Preparation
 #name 2-Item Preparation
 #displayname Item Preparation
 

--- a/TBC/Quest-Preparation.lua
+++ b/TBC/Quest-Preparation.lua
@@ -2,7 +2,7 @@ RXPGuides.RegisterGuide([[
 #classic
 #version 3
 #group Consita Classic/TBC Launch Guide
-#subgroup 2 - Quest Preparation
+#subgroup 2 - Preparation
 #name 1-Quest Preparation
 #displayname Quest Preparation
 #next 2-Item Preparation


### PR DESCRIPTION
Changed the name of the "Quest Preparation" menu item, since it was weird for it to have Item Preparation under it. Makes more sense to just be Preparation